### PR TITLE
[ENG-164] Mirror runner in a private repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,12 +35,24 @@ parameters:
     type: string
     default: "default"
     enum: ["default", "development", "staging", "sepolia-staging"]
+  CI_TRIGGER:
+    type: boolean
+    default: false
 
 jobs:
   publish:
     docker:
       - image: cimg/node:22.4.1
     steps:
+      - run:
+          name: Check CI_TRIGGER
+          command: |
+            if [ "<< pipeline.parameters.CI_TRIGGER >>" != true ]; then
+              echo "CI_TRIGGER is not true. Exiting with success."
+              circleci-agent step halt
+            else
+              echo "CI_TRIGGER is true. Continuing with the workflow."
+            fi
       - run:
           name: Install dependencies
           command: |

--- a/.github/workflows/mirror-private-repo.yml
+++ b/.github/workflows/mirror-private-repo.yml
@@ -1,0 +1,40 @@
+name: Mirror to Private Repository
+
+on:
+  schedule:
+    - cron: '0 * * * *'  # Runs every hour
+  workflow_dispatch:  # Allows manual triggering
+  push:
+    branches:
+      - '*'  # Trigger on pushes to any branch
+      - dm-mirror-private-repo
+
+jobs:
+  mirror_repository:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0  # Fetch all history for all branches and tags
+
+    - name: Push to private repository
+      env:
+        SOURCE_REPO: "earthfast/dashboard-runner"
+        TARGET_REPO: ${{ env.TARGET_PRIVATE_MIRROR_REPO }}
+        GITHUB_PAT: ${{ secrets.GH_PAT }}
+      run: |
+        # Configure Git
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+
+        # Add target remote
+        git remote add target "https://${GH_PAT}@github.com/${TARGET_REPO}.git"
+
+        # Push all branches
+        git push target --all --force
+
+        # Push all tags
+        git push target --tags --force
+
+        echo "Repository mirrored successfully!"

--- a/.github/workflows/mirror-private-repo.yml
+++ b/.github/workflows/mirror-private-repo.yml
@@ -40,10 +40,13 @@ jobs:
 
         # Clone the source repository
         git clone --mirror https://${GH_TOKEN}@github.com/earthfast/dashboard-runner.git source-repo
-
-        # Push to the private repository
         cd source-repo
-        git push --mirror https://${GH_TOKEN}@github.com/earthfast/dashboard-runner-private.git
+
+        # Push branches to the private repository
+        git push --prune https://${GH_TOKEN}@github.com/earthfast/dashboard-runner-private.git +refs/heads/*:refs/heads/*
+
+        # Push tags to the private repository
+        git push --prune https://${GH_TOKEN}@github.com/earthfast/dashboard-runner-private.git +refs/tags/*:refs/tags/*
 
         echo "Repository mirrored successfully!"
 

--- a/.github/workflows/mirror-private-repo.yml
+++ b/.github/workflows/mirror-private-repo.yml
@@ -1,13 +1,12 @@
 name: Mirror to Private Repository
 
 on:
-  schedule:
-    - cron: '0 * * * *'  # Runs every hour
-  workflow_dispatch:  # Allows manual triggering
   push:
     branches:
-      - '*'  # Trigger on pushes to any branch
+      - main
+      - dev
       - dm-mirror-private-repo
+  workflow_dispatch:  # Keeps manual triggering option
 
 jobs:
   mirror_repository:
@@ -21,18 +20,12 @@ jobs:
     - name: Push to private repository
       env:
         GH_TOKEN: ${{ secrets.GH_PAT }}
+        TARGET_PRIVATE_MIRROR_REPO: ${{ secrets.TARGET_PRIVATE_MIRROR_REPO }}
       run: |
         # Configure Git
         git config user.name github-actions
         git config user.email github-actions@github.com
 
-        # Debug: Print Git version
-        git --version
-
-        # Debug: Print target repo URL (masking the token)
-        echo "Target repo: https://github.com/earthfast/dashboard-runner-private.git"
-
-        # Debug: Check if GH_PAT is set
         if [ -z "$GH_TOKEN" ]; then
           echo "Error: GH_PAT is not set"
           exit 1
@@ -43,9 +36,9 @@ jobs:
         cd source-repo
 
         # Push branches to the private repository
-        git push --prune https://${GH_TOKEN}@github.com/earthfast/dashboard-runner-private.git +refs/heads/*:refs/heads/*
+        git push --prune https://${GH_TOKEN}@github.com/${TARGET_PRIVATE_MIRROR_REPO}.git +refs/heads/*:refs/heads/*
 
         # Push tags to the private repository
-        git push --prune https://${GH_TOKEN}@github.com/earthfast/dashboard-runner-private.git +refs/tags/*:refs/tags/*
+        git push --prune https://${GH_TOKEN}@github.com/${TARGET_PRIVATE_MIRROR_REPO}.git +refs/tags/*:refs/tags/*
 
         echo "Repository mirrored successfully!"

--- a/.github/workflows/mirror-private-repo.yml
+++ b/.github/workflows/mirror-private-repo.yml
@@ -49,6 +49,3 @@ jobs:
         git push --prune https://${GH_TOKEN}@github.com/earthfast/dashboard-runner-private.git +refs/tags/*:refs/tags/*
 
         echo "Repository mirrored successfully!"
-
-        # Debug: Check GitHub API rate limit
-        curl -s -H "Authorization: token $GH_TOKEN" https://api.github.com/rate_limit

--- a/.github/workflows/mirror-private-repo.yml
+++ b/.github/workflows/mirror-private-repo.yml
@@ -19,6 +19,8 @@ jobs:
         fetch-depth: 0  # Fetch all history for all branches and tags
 
     - name: Push to private repository
+      env:
+        GH_TOKEN: ${{ secrets.GH_PAT }}
       run: |
         # Configure Git
         git config user.name github-actions
@@ -28,21 +30,25 @@ jobs:
         git --version
 
         # Debug: Print target repo URL (masking the token)
-        echo "Target repo: https://******@github.com/earthfast/dashboard-runner-private.git"
+        echo "Target repo: https://github.com/earthfast/dashboard-runner-private.git"
 
-        # Add target remote
-        git remote add target "https://${{ secrets.GH_PAT }}@github.com/earthfast/dashboard-runner-private.git"
+        # Debug: Check if GH_PAT is set
+        if [ -z "$GH_TOKEN" ]; then
+          echo "Error: GH_PAT is not set"
+          exit 1
+        fi
 
-        # Debug: List remotes
-        git remote -v
+        # Clone the private repository
+        gh repo clone earthfast/dashboard-runner-private /tmp/private-repo || echo "Failed to clone target repository"
 
-        # Debug: Test connection
-        git ls-remote target || echo "Failed to connect to target repository"
+        # If clone successful, push to the private repository
+        if [ -d "/tmp/private-repo" ]; then
+          cd /tmp/private-repo
+          git push --mirror https://github.com/earthfast/dashboard-runner.git
+          echo "Repository mirrored successfully!"
+        else
+          echo "Failed to clone the target repository. Check your GH_PAT permissions."
+        fi
 
-        # Push all branches
-        git push target --all --force || echo "Push failed"
-
-        # Push all tags
-        git push target --tags --force || echo "Tag push failed"
-
-        echo "Repository mirrored successfully!"
+        # Debug: Check GitHub API rate limit
+        curl -s -H "Authorization: token $GH_TOKEN" https://api.github.com/rate_limit

--- a/.github/workflows/mirror-private-repo.yml
+++ b/.github/workflows/mirror-private-repo.yml
@@ -38,19 +38,14 @@ jobs:
           exit 1
         fi
 
-        # Clone the private repository using GH_TOKEN
-        git clone https://${GH_TOKEN}@github.com/earthfast/dashboard-runner-private.git /tmp/private-repo || echo "Failed to clone target repository"
+        # Clone the source repository
+        git clone --mirror https://${GH_TOKEN}@github.com/earthfast/dashboard-runner.git source-repo
 
-        # If clone successful, push to the private repository
-        if [ -d "/tmp/private-repo" ]; then
-          cd /tmp/private-repo
-          git remote add source https://${GH_TOKEN}@github.com/earthfast/dashboard-runner.git
-          git fetch source --tags
-          git push --mirror source
-          echo "Repository mirrored successfully!"
-        else
-          echo "Failed to clone the target repository. Check your GH_PAT permissions."
-        fi
+        # Push to the private repository
+        cd source-repo
+        git push --mirror https://${GH_TOKEN}@github.com/earthfast/dashboard-runner-private.git
+
+        echo "Repository mirrored successfully!"
 
         # Debug: Check GitHub API rate limit
         curl -s -H "Authorization: token $GH_TOKEN" https://api.github.com/rate_limit

--- a/.github/workflows/mirror-private-repo.yml
+++ b/.github/workflows/mirror-private-repo.yml
@@ -19,17 +19,13 @@ jobs:
         fetch-depth: 0  # Fetch all history for all branches and tags
 
     - name: Push to private repository
-      env:
-        SOURCE_REPO: "earthfast/dashboard-runner"
-        TARGET_REPO: ${{ secrets.TARGET_PRIVATE_MIRROR_REPO }}
-        GITHUB_PAT: ${{ secrets.GH_PAT }}
       run: |
         # Configure Git
         git config user.name github-actions
         git config user.email github-actions@github.com
 
         # Add target remote
-        git remote add target "https://${GH_PAT}@github.com/${TARGET_REPO}.git"
+        git remote add target "https://${{ secrets.GH_PAT }}@github.com/${{ secrets.TARGET_PRIVATE_MIRROR_REPO }}.git"
 
         # Push all branches
         git push target --all --force

--- a/.github/workflows/mirror-private-repo.yml
+++ b/.github/workflows/mirror-private-repo.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Push to private repository
       env:
         SOURCE_REPO: "earthfast/dashboard-runner"
-        TARGET_REPO: ${{ env.TARGET_PRIVATE_MIRROR_REPO }}
+        TARGET_REPO: ${{ secrets.TARGET_PRIVATE_MIRROR_REPO }}
         GITHUB_PAT: ${{ secrets.GH_PAT }}
       run: |
         # Configure Git

--- a/.github/workflows/mirror-private-repo.yml
+++ b/.github/workflows/mirror-private-repo.yml
@@ -38,13 +38,15 @@ jobs:
           exit 1
         fi
 
-        # Clone the private repository
-        gh repo clone earthfast/dashboard-runner-private /tmp/private-repo || echo "Failed to clone target repository"
+        # Clone the private repository using GH_TOKEN
+        git clone https://${GH_TOKEN}@github.com/earthfast/dashboard-runner-private.git /tmp/private-repo || echo "Failed to clone target repository"
 
         # If clone successful, push to the private repository
         if [ -d "/tmp/private-repo" ]; then
           cd /tmp/private-repo
-          git push --mirror https://github.com/earthfast/dashboard-runner.git
+          git remote add source https://${GH_TOKEN}@github.com/earthfast/dashboard-runner.git
+          git fetch source --tags
+          git push --mirror source
           echo "Repository mirrored successfully!"
         else
           echo "Failed to clone the target repository. Check your GH_PAT permissions."

--- a/.github/workflows/mirror-private-repo.yml
+++ b/.github/workflows/mirror-private-repo.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0  # Fetch all history for all branches and tags
 

--- a/.github/workflows/mirror-private-repo.yml
+++ b/.github/workflows/mirror-private-repo.yml
@@ -28,10 +28,10 @@ jobs:
         git --version
 
         # Debug: Print target repo URL (masking the token)
-        echo "Target repo: https://******@github.com/${{ secrets.TARGET_PRIVATE_MIRROR_REPO }}.git"
+        echo "Target repo: https://******@github.com/earthfast/dashboard-runner-private.git"
 
         # Add target remote
-        git remote add target "https://${{ secrets.GH_PAT }}@github.com/${{ secrets.TARGET_PRIVATE_MIRROR_REPO }}.git"
+        git remote add target "https://${{ secrets.GH_PAT }}@github.com/earthfast/dashboard-runner-private.git"
 
         # Debug: List remotes
         git remote -v

--- a/.github/workflows/mirror-private-repo.yml
+++ b/.github/workflows/mirror-private-repo.yml
@@ -24,13 +24,25 @@ jobs:
         git config user.name github-actions
         git config user.email github-actions@github.com
 
+        # Debug: Print Git version
+        git --version
+
+        # Debug: Print target repo URL (masking the token)
+        echo "Target repo: https://******@github.com/${{ secrets.TARGET_PRIVATE_MIRROR_REPO }}.git"
+
         # Add target remote
         git remote add target "https://${{ secrets.GH_PAT }}@github.com/${{ secrets.TARGET_PRIVATE_MIRROR_REPO }}.git"
 
+        # Debug: List remotes
+        git remote -v
+
+        # Debug: Test connection
+        git ls-remote target || echo "Failed to connect to target repository"
+
         # Push all branches
-        git push target --all --force
+        git push target --all --force || echo "Push failed"
 
         # Push all tags
-        git push target --tags --force
+        git push target --tags --force || echo "Tag push failed"
 
         echo "Repository mirrored successfully!"


### PR DESCRIPTION
There's two major changes in this PR
1. CircleCI only runs the build and publish workflow if there's a param called CI_TRIGGER set to true, but it defaults to false. This early exits for example when commits are pushed to the repo
2. New github action to mirror to a private repo. That can maintain separate run data