### PR TITLE
Only run mirror-private-repo.yml workflow in dashboard-runner

### DIFF
--- a/.github/workflows/mirror-private-repo.yml
+++ b/.github/workflows/mirror-private-repo.yml
@@ -13,6 +13,14 @@ jobs:
   mirror_repository:
     runs-on: ubuntu-latest
     steps:
+    - name: Check if repository is dashboard-runner
+      run: |
+        REPO_NAME=$(basename -s .git `git config --get remote.origin.url`)
+        if [ "$REPO_NAME" != "dashboard-runner" ]; then
+          echo "This action is only allowed to run in the dashboard-runner repository."
+          exit 0
+        fi
+
     - name: Checkout
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
When the repo is mirrored to the private repo it runs again there, which is unnecessary and throws errors. This code is taken from https://github.com/earthfast/dashboard-runner/blob/022b1d6e877785ad485ed5b59240eec6ca4e4e2e/.github/workflows/trigger-circleci.yml#L27-L33