### PR TITLE
Better default build settings + better nextjs standalone output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,6 +156,10 @@ jobs:
             npm install node-forge
             npm install --global yarn
             npm install --global pnpm
+            sudo apt-get update
+            sudo add-apt-repository ppa:deadsnakes/ppa -y
+            sudo apt-get install -y python3.11 python3.11-venv python3.11-dev
+            alias python3=/usr/bin/python3.11
 
       - when:
           condition:
@@ -266,6 +270,11 @@ jobs:
                 working_directory: ~/project/repository
                 command: |
                   set -e
+
+                  # Load prerequisites
+                  alias python3=/usr/bin/python3.11
+                  export NODE_OPTIONS=--max_old_space_size=7168
+
                   [ -f ~/project/.env ] && source ~/project/.env
                   [ -f ~/project/.env.ef_circleci ] && source ~/project/.env.ef_circleci
                   [ -n "<< pipeline.parameters.BUILD_DIR >>" ] && cd "<< pipeline.parameters.BUILD_DIR >>"
@@ -281,6 +290,11 @@ jobs:
                 working_directory: ~/project/repository
                 command: |
                   set -e
+
+                  # Load prerequisites and set nextjs standalone mode
+                  alias python3=/usr/bin/python3.11
+                  export NEXT_PRIVATE_STANDALONE=true
+                  export NODE_OPTIONS=--max_old_space_size=7168
 
                   # Function to log messages
                   log() {
@@ -301,7 +315,7 @@ jobs:
                   # Install dependencies
                   if [ -n "<< pipeline.parameters.PACKAGE_INSTALL_COMMAND >>" ]; then
                     log "Installing dependencies..."
-                    eval "NEXT_PRIVATE_STANDALONE=true << pipeline.parameters.PACKAGE_INSTALL_COMMAND >>"
+                    eval "<< pipeline.parameters.PACKAGE_INSTALL_COMMAND >>"
                   else
                     log "Error: PACKAGE_INSTALL_COMMAND is not set. Exiting."
                     exit 1
@@ -310,7 +324,7 @@ jobs:
                   # Build the project
                   if [ -n "<< pipeline.parameters.BUILD_COMMAND >>" ]; then
                     log "Building the project..."
-                    eval "NEXT_PRIVATE_STANDALONE=true << pipeline.parameters.BUILD_COMMAND >>"
+                    eval "<< pipeline.parameters.BUILD_COMMAND >>"
                   else
                     log "Error: BUILD_COMMAND is not set. Exiting."
                     exit 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,9 +156,9 @@ jobs:
             npm install node-forge
             npm install --global yarn
             npm install --global pnpm
-            sudo apt-get update
-            sudo add-apt-repository ppa:deadsnakes/ppa -y
-            sudo apt-get install -y python3.11 python3.11-venv python3.11-dev
+            # sudo apt-get update
+            # sudo add-apt-repository ppa:deadsnakes/ppa -y
+            # sudo apt-get install -y python3.11 python3.11-venv python3.11-dev
 
       - when:
           condition:
@@ -271,8 +271,8 @@ jobs:
                   set -e
 
                   # Load prerequisites
-                  alias python3=/usr/bin/python3.11
-                  export PYTHON=/usr/bin/python3.11
+                  # alias python3=/usr/bin/python3.11
+                  # export PYTHON=/usr/bin/python3.11
                   export NODE_OPTIONS=--max_old_space_size=7168
 
                   [ -f ~/project/.env ] && source ~/project/.env
@@ -292,8 +292,8 @@ jobs:
                   set -e
 
                   # Load prerequisites and set nextjs standalone mode
-                  alias python3=/usr/bin/python3.11
-                  export PYTHON=/usr/bin/python3.11
+                  # alias python3=/usr/bin/python3.11
+                  # export PYTHON=/usr/bin/python3.11
                   export NEXT_PRIVATE_STANDALONE=true
                   export NODE_OPTIONS=--max_old_space_size=7168
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,6 @@ jobs:
             sudo apt-get update
             sudo add-apt-repository ppa:deadsnakes/ppa -y
             sudo apt-get install -y python3.11 python3.11-venv python3.11-dev
-            alias python3=/usr/bin/python3.11
 
       - when:
           condition:
@@ -273,6 +272,7 @@ jobs:
 
                   # Load prerequisites
                   alias python3=/usr/bin/python3.11
+                  export PYTHON=/usr/bin/python3.11
                   export NODE_OPTIONS=--max_old_space_size=7168
 
                   [ -f ~/project/.env ] && source ~/project/.env
@@ -293,6 +293,7 @@ jobs:
 
                   # Load prerequisites and set nextjs standalone mode
                   alias python3=/usr/bin/python3.11
+                  export PYTHON=/usr/bin/python3.11
                   export NEXT_PRIVATE_STANDALONE=true
                   export NODE_OPTIONS=--max_old_space_size=7168
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,9 +156,7 @@ jobs:
             npm install node-forge
             npm install --global yarn
             npm install --global pnpm
-            # sudo apt-get update
-            # sudo add-apt-repository ppa:deadsnakes/ppa -y
-            # sudo apt-get install -y python3.11 python3.11-venv python3.11-dev
+            sudo apt-get update
 
       - when:
           condition:
@@ -271,8 +269,6 @@ jobs:
                   set -e
 
                   # Load prerequisites
-                  # alias python3=/usr/bin/python3.11
-                  # export PYTHON=/usr/bin/python3.11
                   export NODE_OPTIONS=--max_old_space_size=7168
 
                   [ -f ~/project/.env ] && source ~/project/.env
@@ -292,8 +288,6 @@ jobs:
                   set -e
 
                   # Load prerequisites and set nextjs standalone mode
-                  # alias python3=/usr/bin/python3.11
-                  # export PYTHON=/usr/bin/python3.11
                   export NEXT_PRIVATE_STANDALONE=true
                   export NODE_OPTIONS=--max_old_space_size=7168
 


### PR DESCRIPTION
This PR has two changes which simplify the build command
1. Bump up node max memory to 7168MB (some builds were running OOM)
2. Move NEXT_PRIVATE_STANDALONE to standalone export statement (if you chained together multiple commands like <cmd> && <cmd> && <cmd>... eval didn't work as expected)

I had a third change setting python to 3.11, which is the last version with distutils which had global node-gyp compatibility. I removed it because these base images have python3.8 which works and builds node-gyp fine. I decided not to add that python change because in the future I didnt want to lock us in, we can always add that back in. For the time being if you need to build something which has node-gyp but you have python3.12+ either downgrade to 3.11 or run `python3 -m pip install packaging` from [here](https://github.com/nodejs/node-gyp/issues/2869)

Working run https://app.circleci.com/pipelines/github/earthfast/dashboard-runner/4431/workflows/018cba3c-62b5-493f-88b8-47e37fb07dd2/jobs/4333
